### PR TITLE
Included missing dependencies

### DIFF
--- a/doc/WeeklyProgress.md
+++ b/doc/WeeklyProgress.md
@@ -413,6 +413,7 @@ Initial meeting with team:
 - Worked on thumbnail functionality
   - Configured DigitalOcean Spaces for thumbnails
   - Implemented capturing a thumbnail, uploading it to DO Spaces, displaying on webapp
+- Updated GitHub Secrets
 
 #### Catherine Jin
 

--- a/footnote-backend/package-lock.json
+++ b/footnote-backend/package-lock.json
@@ -21,6 +21,7 @@
         "express": "~4.16.1",
         "express-mysql-session": "^3.0.3",
         "express-session": "^1.18.1",
+        "fluent-ffmpeg": "^2.1.3",
         "footnote": "file:..",
         "http-errors": "~1.6.3",
         "jade": "~1.11.0",
@@ -1986,6 +1987,11 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
       "integrity": "sha512-Ej9qjcXY+8Tuy1cNqiwNMwFRXOy9UwgTeMA8LxreodygIPV48lx8PU1ecFxb5ZeU1DpMKxiq6vGLTxcitWZPbA=="
     },
+    "node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3072,6 +3078,19 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/fluent-ffmpeg": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
+      "integrity": "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^0.2.9",
+        "which": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/footnote": {
       "resolved": "..",
       "link": true
@@ -3552,6 +3571,12 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/jade": {
       "version": "1.11.0",
@@ -5286,6 +5311,18 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/wide-align": {

--- a/footnote-backend/package.json
+++ b/footnote-backend/package.json
@@ -20,6 +20,7 @@
     "express": "~4.16.1",
     "express-mysql-session": "^3.0.3",
     "express-session": "^1.18.1",
+    "fluent-ffmpeg": "^2.1.3",
     "footnote": "file:..",
     "http-errors": "~1.6.3",
     "jade": "~1.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
       "name": "footnote",
       "version": "1.0.0",
       "dependencies": {
-        "bootstrap-icons": "^1.11.3",
-        "fluent-ffmpeg": "^2.1.3"
+        "bootstrap-icons": "^1.11.3"
       },
       "devDependencies": {
         "concurrently": "^8.2.0",
@@ -51,11 +50,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
     },
     "node_modules/bootstrap-icons": {
       "version": "1.11.3",
@@ -191,19 +185,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/fluent-ffmpeg": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
-      "integrity": "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==",
-      "license": "MIT",
-      "dependencies": {
-        "async": "^0.2.9",
-        "which": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -230,12 +211,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -349,18 +324,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "bootstrap-icons": "^1.11.3",
-    "fluent-ffmpeg": "^2.1.3"
+    "bootstrap-icons": "^1.11.3"
   }
 }


### PR DESCRIPTION
* footnote-backend was missing `fluent-ffmpeg` library - is now included
* root directory doesn't need `fluent-ffmpeg` library - is now removed
* tests are failing because API endpoints are returning more information now for thumbnail functionality to work - tests should update to reflect this